### PR TITLE
feat: upgrade package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+sonic (0.2.0-12) unstable; urgency=medium
+
+  * control: Bump Standards-Version to 4.6.0 (no change)
+  * rules: Bump java compatibility to 1.7.
+
+ -- Samuel Thibault <sthibault@debian.org>  Wed, 25 May 2022 17:20:40 +0200
+
 sonic (0.2.0-11) unstable; urgency=medium
 
   [ Samuel Thibault ]

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: Bill Cox <waywardgeek@gmail.com>, Samuel Thibault <sthibault@debian.o
 Build-Depends: debhelper-compat (= 13)
 Build-Depends-Indep: default-jdk
 Rules-Requires-Root: no
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Homepage: https://github.com/waywardgeek/sonic
 Vcs-Browser: https://salsa.debian.org/a11y-team/sonic
 Vcs-Git: https://salsa.debian.org/a11y-team/sonic.git

--- a/debian/rules
+++ b/debian/rules
@@ -15,7 +15,7 @@ include /usr/share/dpkg/architecture.mk
 
 sonic/Sonic.class: Sonic.java
 	[ -L sonic ] || ln -s . sonic
-	javac -source 1.6 -target 1.6 $<
+	javac -source 1.7 -target 1.7 $<
 
 sonic.jar: sonic/Sonic.class
 	jar -cf $@ $^


### PR DESCRIPTION
fix:  error: Source option 6 is no longer supported. Use 7 or later.